### PR TITLE
Make some types public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,7 @@ pub use self::instruction::Instruction;
 pub use self::loops::{find_loops, LoopStructureGraph, SimpleLoop};
 pub use self::memory::{Error, Memory, Segment};
 pub use self::symbol::Symbol;
+pub use self::disassembler::{Disassembler, Architecture};
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
At the moment, `Disassembler` trait is needed to implement `Instruction` (all the methods needs a `Disassembler` parameter).
As `Disassembler` (and `Architecture`) are not public, it's impossible to implement the `Instruction` trait from outside the crate. With this change, implementing the `Instruction` trait will be possible.